### PR TITLE
Handle QML / QMake files

### DIFF
--- a/contrib/syntax.yml
+++ b/contrib/syntax.yml
@@ -74,6 +74,13 @@ qml:
     close:  ' */\n\n'
     prefix: ' * '
 
+qmake_project:
+  ext: ['.pro']
+  comment:
+    open:   '#\n'
+    close:  '#\n'
+    prefix: '# '
+
 css:
   ext: ['.css']
   comment:

--- a/contrib/syntax.yml
+++ b/contrib/syntax.yml
@@ -67,6 +67,13 @@ javacript:
     close:  ' */\n\n'
     prefix: ' * '
 
+qml:
+  ext: ['.qml']
+  comment:
+    open:   '/*\n'
+    close:  ' */\n\n'
+    prefix: ' * '
+
 css:
   ext: ['.css']
   comment:


### PR DESCRIPTION
This PR adds support for QML and QMake project files.  (Both file types occur often in projects using Qt.)

More information:

- QML:
  - https://doc.qt.io/qt-5/qmlreference.html
  - https://doc.qt.io/qt-5/qtqml-syntax-basics.html#comments
- QMake:
  - https://doc.qt.io/qt-5/qmake-project-files.html#comments