### PR TITLE
Support ruby magic comment & rubocop rules.

### DIFF
--- a/contrib/syntax.yml
+++ b/contrib/syntax.yml
@@ -19,9 +19,9 @@
 #
 ruby:
   ext: ['.rb', '.rake']
-  after: ['^#!', '^#.*encoding:']
+  after: ['^#!', '^#.*encoding:', '^#.*frozen_string_literal:']
   comment:
-    open:   '#\n'
+    open:   '\n#\n'
     close:  '#\n'
     prefix: '# '
 


### PR DESCRIPTION
Magic comments should be first in the file; and a space should exist between them and the copyright.